### PR TITLE
fix and modify nginx settings

### DIFF
--- a/installation/nginx.md
+++ b/installation/nginx.md
@@ -33,18 +33,27 @@ enabled=0
 ```
 server {
     listen 80;
+    # server_name にドメイン名を適切に設定する。
+    # SHIRASAGI の管理画面からサイトの設定を確認し、
+    # ドメインに公開ドメインが設定されていることを確認する。
     server_name example.jp;
+    # root にSHIRASAGI をインストールしたディレクトリ下の `public/sites/w/w/w/_/` を指定する。
     root /var/www/ss/public/sites/w/w/w/_/;
-    
+
     location @app {
         if ($request_filename ~ .*\.(ico|gif|jpe?g|png|css|js)$) { access_log  off; }
         proxy_pass http://127.0.0.1:3000;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Server $host;
     }
     location / {
         expires 1h;
-        try_files $uri $uri @app;
+        try_files $uri $uri/index.html @app;
     }
     location /assets/ {
+        # root にSHIRASAGI をインストールしたディレクトリ下の `public` を指定する。
         root /var/www/ss/public/;
         expires 1h;
         access_log off;
@@ -53,7 +62,7 @@ server {
         expires 1h;
         access_log off;
         log_not_found off;
-        try_files $uri $uri @app;
+        try_files $uri @app;
     }
 }
 ```


### PR DESCRIPTION
* `try_files $uri $uri` と `$uri` を 2 回 try する意味は薄いと考え、2 回目の try を '$uri/index.html' に変更。
  * directory listing が誤って有効になっていると、ネットでよく見かける `$uri/` では、アクセスした際にディレクトリリストが表示されてしまうので、`$uri/index.html` の方がよいと判断。
  * directory listing が無効の場合（これが想定であり既定）、`$uri/` にアクセスしたら失敗するので、`$uri/index.html` の方がよいと判断。
* `X-Real-IP` や `X-Forwarded-For` などの Reverse Proxy 系の proxy header を追加。
  この設定がないと、`SS::Site` を `127.0.0.1:3000` で検索し、サイトが見つからないので Not Found となる。
