### PR TITLE
remove unnecessary blank after url

### DIFF
--- a/javascripts/script.js
+++ b/javascripts/script.js
@@ -1,7 +1,7 @@
 $(function(){
   $(".main-content").each(function(){
-    // autolink
-    $(this).html($(this).html().replace(/((http|https|ftp):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g,
-      '<a href="$1">$1</a> '));
+   // autolink
+   $(this).html($(this).html().replace(/((http|https|ftp):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g,
+     '<a href="$1">$1</a>'));
   });
 });


### PR DESCRIPTION
例えば Manual Install のページの mongo repository の URL が:

    baseurl=http://repo.mongodb.org/yum/redhat/ $releasever/mongodb-org/3.0/x86_64/

と余分なスペースを含むようになり、コピペできなくなっています。
余分なスペースを挿入しないようにしました。