### PR TITLE
[fix] add option "--disable-binary" to "rvm install"

### DIFF
--- a/installation/linux-mint-19.1.md
+++ b/installation/linux-mint-19.1.md
@@ -35,7 +35,7 @@ $ sudo apt-add-repository -y ppa:rael-gc/rvm
 $ sudo apt-get update
 $ sudo apt-get install -y rvm
 $ source /usr/share/rvm/scripts/rvm #(Run command as login shell)
-$ rvm install ruby 2.6.3
+$ rvm install ruby 2.6.3 --disable-binary
 $ rvm use 2.6.3 --default
 ```
 

--- a/installation/manual.md
+++ b/installation/manual.md
@@ -108,7 +108,7 @@ gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc
 # gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 # \curl -sSL https://get.rvm.io | sudo bash -s stable
 # source /etc/profile
-# rvm install 2.6.3
+# rvm install 2.6.3 --disable-binary
 # rvm use 2.6.3 --default
 # gem install bundler
 ~~~

--- a/installation/ubuntu.md
+++ b/installation/ubuntu.md
@@ -53,7 +53,7 @@ MongoDB の [Official installation](https://docs.mongodb.com/manual/tutorial/ins
 # echo '[[ -s "/usr/local/rvm/scripts/rvm" ]] && source "/usr/local/rvm/scripts/rvm"' >> ~/.bashrc
 # source /usr/local/rvm/scripts/rvm
 # /usr/local/rvm/bin/rvm requirements
-# rvm install 2.6.3
+# rvm install 2.6.3 --disable-binary
 # rvm use 2.6.3 --default
 # gem install bundler --no-document
 ~~~

--- a/updation/ruby.md
+++ b/updation/ruby.md
@@ -12,6 +12,16 @@ $ su -
 # rvm use 2.6.3 --default
 ~~~
 
+`rvm get stable` を実行した際に `Warning, RVM 1.26.0 introduces signed releases and automated check of signatures ...` のようなエラーが表示された場合、次のコマンドを実行し、適切な GPG キーをインポートしてください。
+
+~~~
+command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+~~~
+
+参考: <https://github.com/rvm/rvm/issues/4533>
+
+何もエラーが表示されない場合は GPG キーのインポートは不要です。
+
 ## Mecab Ruby
 
 ~~~

--- a/updation/ruby.md
+++ b/updation/ruby.md
@@ -7,8 +7,8 @@ title: Ruby の更新
 
 ~~~
 $ su -
-# rvm get latest
-# rvm install 2.6.3
+# rvm get stable
+# rvm install 2.6.3 --disable-binary
 # rvm use 2.6.3 --default
 ~~~
 


### PR DESCRIPTION
for protecting to install improperly configured ruby (wrong binary).