### PR TITLE
MeCab インストール手順を GitHub リポジトリからのビルドに変更

### DIFF
--- a/installation/almalinux.md
+++ b/installation/almalinux.md
@@ -248,32 +248,30 @@ $ bundle exec rake unicorn:start
 
 ```
 $ sudo su
-# asdf global ruby VERSION
 # cd /usr/local/src
-# wget -O mecab-0.996.tar.gz "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7cENtOXlicTFaRUE&confirm=t&uuid=585a8a12-a314-4ca2-b3e6-9df561267c5e&at=AKKF8vxZJ7Wpcz3usXa_4TL4-cUH:1682584842486"
-# wget -O mecab-ipadic-2.7.0-20070801.tar.gz "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7MWVlSDBCSXZMTXM"
-# wget -O mecab-ruby-0.996.tar.gz "https://drive.google.com/uc?export=download&id=0B4y35FiV1wh7VUNlczBWVDZJbE0"
-# wget https://raw.githubusercontent.com/shirasagi/shirasagi/stable/vendor/mecab/mecab-ipadic-2.7.0-20070801.patch
+# git clone --depth 1 https://github.com/taku910/mecab.git
 
-# cd /usr/local/src
-# tar xvzf mecab-0.996.tar.gz && cd mecab-0.996
+# MeCab本体
+# cd /usr/local/src/mecab/mecab
 # ./configure --enable-utf8-only && make && make install
 
-# cd /usr/local/src
-# tar xvzf mecab-ipadic-2.7.0-20070801.tar.gz && cd mecab-ipadic-2.7.0-20070801
-# patch -p1 < ../mecab-ipadic-2.7.0-20070801.patch
-# ./configure --with-charset=UTF-8 && make && make install
-
-# cd /usr/local/src
-# tar xvzf mecab-ruby-0.996.tar.gz && cd mecab-ruby-0.996
-# ruby extconf.rb && make && make install
-
+# 共有ライブラリの登録
 # echo "/usr/local/lib" >> /etc/ld.so.conf
 # ldconfig
+
+# 辞書（SHIRASAGI用パッチ適用）
+# export PATH=/usr/local/bin:$PATH
+# cd /usr/local/src/mecab/mecab-ipadic
+# curl -fsSLO https://raw.githubusercontent.com/shirasagi/shirasagi/stable/vendor/mecab/mecab-ipadic-2.7.0-20070801.patch
+# patch -p1 < mecab-ipadic-2.7.0-20070801.patch
+# ./configure --with-charset=UTF-8 && make && make install
+
+# Ruby拡張
+# cd /usr/local/src/mecab/mecab/ruby
+# ruby extconf.rb && make && make install
 ```
 
-> mecab ビルド後に `ldconfig` が必要なケースがあります。<br>
-> 環境変数 PATH に/usr/local/bin を追記が必要なケースがあります。
+> パッチは月の読みを修正するためのものです（例: 1月 → イチガツ）。
 
 ## 音声読み上げ機能のインストール
 


### PR DESCRIPTION
## 概要

MeCab のインストール手順を Google Drive からのダウンロードから GitHub リポジトリからのビルドに変更します。

## 変更内容

- Google Drive からのダウンロードを GitHub リポジトリ (taku910/mecab) からの git clone に変更
- ldconfig を MeCab 本体インストール直後に移動（辞書ビルド前に必要）
- 辞書インストール前に `export PATH=/usr/local/bin:$PATH` を追加（asdf 環境で mecab-config を認識させるため）
- wget を curl -fsSLO に変更
- 各ステップにコメントを追加
- 曖昧な注記を具体的なパッチ説明に変更

## 変更理由

1. **Google Drive の URL が不安定** - 長い URL パラメータが必要で、将来的に変更される可能性がある
2. **GitHub リポジトリが公式** - taku910/mecab は MeCab 作者の公式リポジトリ
3. **PATH 問題の解決** - asdf 環境では root の PATH に /usr/local/bin が含まれていないため、mecab-config が見つからないエラーが発生していた

## 検証環境

- AlmaLinux 8.10
- asdf v0.15.0
- Ruby 3.2.3

## 検証結果

| 項目 | 結果 |
|------|------|
| MeCab 本体 | ✅ mecab of 0.996 |
| パッチ効果 | ✅ 1月→イチガツ、2月→ニガツ、3月→サンガツ |
| Ruby 連携 | ✅ MeCab::VERSION = 0.996 |
| kana.yml 変更 | 不要（デフォルト設定と一致）|
