### PR TITLE
[fix] リキッドリファレンスに複数ファイルアップロード・画像リストの項目を追加

### DIFF
--- a/features/liquid/reference.md
+++ b/features/liquid/reference.md
@@ -293,6 +293,50 @@ title: リファレンス
 ~~~
 {% endraw %}
 
+### 添付ファイル（複数）・画像リスト
+
+`multiple_files_upload`（添付ファイル（複数））と画像リストで使用できます。
+
+| 変数         | 説明 |
+|-------------|--------------------------------------------|
+| value.html  | 設定にしたがって入力値を HTML 化したもので既定値です。既定値は下を参照。
+| value.file_type | アップロードの種類。`image`（画像リスト）または `attachment`（添付ファイル（複数））の文字列。
+| value.header | 説明文（見出し）
+| value.files | ファイルの配列
+| value.file_labels | ファイルの ID をキー、ファイルのタイトルを値にしたハッシュ
+| value.items | 各ファイルの配列。各要素は `file`（ファイル）、`label`（ファイルのタイトル）、`file_label`（ファイルのタイトルを文字列化したもの）を持つ。
+
+#### value.html
+
+{% raw %}
+~~~
+{% if value.header.size > 0 %}
+  {% if value.file_type == 'image' %}
+    <div class="images-header">{{ value.header | newline_to_br }}</div>
+  {% else %}
+    <div class="attachment-header">{{ value.header | newline_to_br }}</div>
+  {% endif %}
+{% endif %}
+{% if value.items.size > 0 %}
+  {% if value.file_type == 'image' %}
+    <div class="column2">
+      {% for item in value.items %}
+        <div class="column-item">
+          <img src="{{ item.file.url }}" alt="{{ item.file_label }}">
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <ul class="attachment-list">
+      {% for item in value.items %}
+        <li><a href="{{ item.file.url }}">{{ item.label | default: item.file.humanized_name }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endif %}
+~~~
+{% endraw %}
+
 ### 見出し入力
 
 | 変数         | 説明 |


### PR DESCRIPTION
## 概要

shirasagi/shirasagi#6053 で追加された複数ファイルアップロードブロック（添付ファイル（複数 / `multiple_files_upload`）・画像リスト）について、リキッド形式のリファレンスに項目を追加しました。

| カラム種類 | 「説明」にあたる項目 | レイアウトでのタグ |
|-----------|---------------------|-------------------|
| 添付ファイル（複数 / multiple_files_upload）・画像リスト | 説明文（header） | {% raw %}`{{ value.header }}`{% endraw %} |

## 変更内容

`features/liquid/reference.md` の「ファイルアップロード」セクションの後に、「添付ファイル（複数）・画像リスト」セクションを新設しました。

`{{ value.header }}`（説明文）に加え、ブロックで利用できる以下のリキッド変数を記載しています。

- `value.html` … 既定の HTML
- `value.file_type` … `image`（画像リスト）/ `attachment`（添付ファイル（複数））
- `value.header` … 説明文（見出し）
- `value.files` … ファイルの配列
- `value.file_labels` … ファイル ID をキーにしたタイトルのハッシュ
- `value.items` … 各ファイル（`file` / `label` / `file_label`）の配列

また、既定の `value.html` 出力例も合わせて記載しました。

https://claude.ai/code/session_01MTzzkJicCGVCKx4fiBvHWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTzzkJicCGVCKx4fiBvHWx)_